### PR TITLE
Rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+rust:
+- nightly
 before_script:
 - rustup component add rustfmt-preview
 script:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,16 @@
+# Hard tabs forces tabs for indents, and spaces for formatting. 
+hard_tabs = true
+
+# Sets maximum line width, default is 100 but just keeping this in for clarity. 
+max_width = 100
+
+# Blank lines upper bound sets the maximum amount of blank lines between lines. If it goes over, 
+#empty lines will be trimmed until it's at the upper bound
+blank_lines_upper_bound = 2
+
+# Ignore function for ignoring specific files within the directory. To add a file to ignore,
+#simply add its path and file name in quotations between the brackets. Useful for non .rs files.  
+#example: "src/types.rs"
+ignore = [
+
+]

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,7 @@
+language: rust
+before_script:
+- rustup component add rustfmt-preview
+script:
+- cargo fmt --all -- --check
+- cargo build
+- cargo test


### PR DESCRIPTION
# Fixes

This will allow Travis CI to automatically format code be placed inside of the Github repository. We'll have to set up the second CI repo to get this working, but this is as barebones as the config file can get.

Additionally, the rustfmt config has been edited to remove any of the extra features that comes with using default settings and only formats what we need. I have a feeling we may need to end up adding a bit more, because as of right now it only manages the amount of spaces between lines, spaces and tabs, and other small things. If we want truly uniform code, we'll have to include the bits that manages how code blocks are formatted. 

## Related Issues

- None so far, but Travis CI may need to be tested with the current config settings. 
